### PR TITLE
Added dependency on Spreadsheet::Read v0.68 to fix the fail report.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -38,6 +38,7 @@ run = mv tmp/Changes Changes
 
 [GatherDir]
 [Prereqs]
+Spreadsheet::Read = 0.68
 [AutoPrereqs]
 [PruneCruft]
 [PruneFiles]


### PR DESCRIPTION
Hi @sdondley 

Please review the PR.
https://www.cpantesters.org/cpan/report/1b7ad62e-3478-11e9-9b41-fcfad1ab4f31

          #   Failed test 'Can create new object'
          #   at t/01-basic.t line 32.
          # died: Can't locate object method "new" via package "Spreadsheet::Read" at /home/cpansand/.cpan/build/2019021912/Spreadsheet-Read-Ingester-0.003-2/blib/lib/Spreadsheet/Read/Ingester.pm line 32.
     
          #   Failed test 'created parsed file'


OO interface was introduced in Spreadsheet::Read v0.68 according to the Changes.

          0.68    - 29 Nov 2016, H.Merijn Brand
          * List non-core modules/version used on very verbose in xlscat
          * Option to export all sheets in a spreadsheet to CSV (UTF-8 only)
          * Add OO interface
          * Feature: add new spreadsheets to existing book (even of different types)

Many Thanks.
Best Regards,
Mohammad S Anwar